### PR TITLE
wrap lists of terms with square brackets for tree output.

### DIFF
--- a/srcgen/xats/DATS/intrep0_print.dats
+++ b/srcgen/xats/DATS/intrep0_print.dats
@@ -13,12 +13,12 @@
 ** the terms of  the GNU GENERAL PUBLIC LICENSE (GPL) as published by the
 ** Free Software Foundation; either version 3, or (at  your  option)  any
 ** later version.
-** 
+**
 ** ATS is distributed in the hope that it will be useful, but WITHOUT ANY
 ** WARRANTY; without  even  the  implied  warranty  of MERCHANTABILITY or
 ** FITNESS FOR A PARTICULAR PURPOSE.  See the  GNU General Public License
 ** for more details.
-** 
+**
 ** You  should  have  received  a  copy of the GNU General Public License
 ** along  with  ATS;  see the  file COPYING.  If not, please write to the
 ** Free Software Foundation,  51 Franklin Street, Fifth Floor, Boston, MA
@@ -254,7 +254,7 @@ x0.node() of
   fprint!
   ( out
   , "IR0Edapp("
-  , irf0, "; ", npf1, "; ", ires, ")")
+  , irf0, "; ", npf1, "; [", ires, "])")
 //
 | IR0Eproj
   (ire1, lab2, idx2) =>

--- a/srcgen/xats/DATS/intrep0_print.dats
+++ b/srcgen/xats/DATS/intrep0_print.dats
@@ -240,14 +240,14 @@ x0.node() of
   fprint!
   ( out
   , "IR0Etcst("
-  , d2c1, "; ", ti3a, "; ", ti2s, ")")
+  , d2c1, "; ", ti3a, "; [", ti2s, "])")
 | IR0Etimp
   ( ire1
   , targ, irc2, tsub) =>
   fprint!
   ( out
   , "IR0Etimp("
-  , ire1, "; ", targ, "; ", irc2, "; ", tsub)
+  , ire1, "; [", targ, "]; ", irc2, "; [", tsub, "])")
 //
 | IR0Edapp
   (irf0, npf1, ires) =>
@@ -270,14 +270,14 @@ x0.node() of
 | IR0Ewhere(ire1, irds) =>
   fprint!
   ( out
-  , "IR0Ewhere(", ire1, "; ", irds, ")")
+  , "IR0Ewhere(", ire1, "; [", irds, "])")
 //
 | IR0Etuple
   (knd0, npf1, ires) =>
   fprint!
   ( out
   , "IR0Etuple("
-  , knd0, "; ", npf1, "; ", ires, ")")
+  , knd0, "; ", npf1, "; [", ires, "])")
 //
 | IR0Eif0
   (ire1, ire2, opt3) =>
@@ -295,13 +295,13 @@ x0.node() of
   (knd0, farg, body) =>
   fprint!
   ( out, "IR0Elam("
-  , knd0, "; ", farg, "; ", body, ")")
+  , knd0, "; [", farg, "]; ", body, ")")
 | IR0Efix
   (knd0, d2v0, farg, body) =>
   fprint!
   ( out, "IR0Efix("
   , knd0, "; "
-  , d2v0, "; ", farg, "; ", body, ")")
+  , d2v0, "; [", farg, "]; ", body, ")")
 //
 | IR0Enone0() =>
   (

--- a/srcgen/xint/DATS/interp0_print.dats
+++ b/srcgen/xint/DATS/interp0_print.dats
@@ -109,7 +109,7 @@ case+ x0 of
 | IR0Vtuple(knd, irvs) =>
   fprint!
   ( out
-  , "IR0Vtuple(", knd, "; ", irvs, ")")
+  , "IR0Vtuple(", knd, "; [", irvs, "])")
 //
 | IR0Vlam
   (fenv, iras, ire1) =>

--- a/srcgen/xint/DATS/interp0_print.dats
+++ b/srcgen/xint/DATS/interp0_print.dats
@@ -13,12 +13,12 @@
 ** the terms of  the GNU GENERAL PUBLIC LICENSE (GPL) as published by the
 ** Free Software Foundation; either version 3, or (at  your  option)  any
 ** later version.
-** 
+**
 ** ATS is distributed in the hope that it will be useful, but WITHOUT ANY
 ** WARRANTY; without  even  the  implied  warranty  of MERCHANTABILITY or
 ** FITNESS FOR A PARTICULAR PURPOSE.  See the  GNU General Public License
 ** for more details.
-** 
+**
 ** You  should  have  received  a  copy of the GNU General Public License
 ** along  with  ATS;  see the  file COPYING.  If not, please write to the
 ** Free Software Foundation,  51 Franklin Street, Fifth Floor, Boston, MA
@@ -72,10 +72,10 @@ fprint_val<ir0val> = fprint_ir0val
 (* ****** ****** *)
 //
 implement
-print_ir0val(x0) = 
+print_ir0val(x0) =
 fprint_ir0val(stdout_ref, x0)
 implement
-prerr_ir0val(x0) = 
+prerr_ir0val(x0) =
 fprint_ir0val(stderr_ref, x0)
 //
 implement
@@ -101,7 +101,7 @@ case+ x0 of
 | IR0Vcon(d2c, xs) =>
   fprint!
   ( out
-  , "IR0Vcon(", d2c, "; ", xs, ")")
+  , "IR0Vcon(", d2c, "; [", xs, "] )")
 //
 | IR0Vfun(fopr) =>
   fprint!(out, "IR0Vfun(", "...", ")")

--- a/srcgen/xint/DATS/interp0_print.dats
+++ b/srcgen/xint/DATS/interp0_print.dats
@@ -101,7 +101,7 @@ case+ x0 of
 | IR0Vcon(d2c, xs) =>
   fprint!
   ( out
-  , "IR0Vcon(", d2c, "; [", xs, "] )")
+  , "IR0Vcon(", d2c, "; [", xs, "])")
 //
 | IR0Vfun(fopr) =>
   fprint!(out, "IR0Vfun(", "...", ")")


### PR DESCRIPTION
Aids in reading through output tree (in particular when list is empty -- otherwise output is blank)
```ats
// For example:

IR0Vcon(list_nil(6); [] )

// in place of

IR0Vcon(list_nil(6);  )
```