### PR TITLE
fix: typedef for long doubles

### DIFF
--- a/prelude/basics.sats
+++ b/prelude/basics.sats
@@ -734,7 +734,7 @@ typedef
 dfloat_k =
 $extype("xats_dfloat_t")
 typedef
-dfloat_k =
+ldfloat_k =
 $extype("xats_ldfloat_t")
 //
 abstype


### PR DESCRIPTION
previously calling `./srcgen/xats/xatsopt -s prelude/basics.sats` failed in the trans12 stage:
```
tread12_program: nxerr = 2
tread12_program: there are some trans12-errors!
```

Either because there was already a typedef called `dfloat_k` or because of the later usage of an undefined `ldfloat_k`.